### PR TITLE
Refactor match service and add new methods

### DIFF
--- a/apps/client/src/app/guards/match/match.guard.spec.ts
+++ b/apps/client/src/app/guards/match/match.guard.spec.ts
@@ -1,14 +1,12 @@
-import {TestBed} from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
-import {MatchGuard} from './match.guard';
-import {Socket} from 'ngx-socket-io';
-import {Router, RouterStateSnapshot} from '@angular/router';
-import {Observable} from 'rxjs';
-import {MatchService} from 'src/app/services/match/match.service';
+import { Socket } from 'ngx-socket-io';
+import { Router, RouterStateSnapshot } from '@angular/router';
+import { MatchService } from 'src/app/services/match/match.service';
+import { MatchGuard } from './match.guard';
 
 describe('MatchGuard', () => {
-  let guard: MatchGuard;
-  let socketService: jasmine.SpyObj<Socket>;
+  let guard: typeof MatchGuard;
   let routerService: jasmine.SpyObj<Router>;
   let service: jasmine.SpyObj<MatchService>;
 
@@ -27,14 +25,13 @@ describe('MatchGuard', () => {
 
     TestBed.configureTestingModule({
       providers: [
-        {provide: Socket, useValue: socketSpy},
-        {provide: Router, useValue: routerSpy},
-        {provide: MatchService, useValue: serviceSpy},
+        { provide: Socket, useValue: socketSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: MatchService, useValue: serviceSpy },
       ],
     });
-    guard = TestBed.inject(MatchGuard);
+    guard = MatchGuard;
     routerService = TestBed.inject(Router) as jasmine.SpyObj<Router>;
-    socketService = TestBed.inject(Socket) as jasmine.SpyObj<Socket>;
     service = TestBed.inject(MatchService) as jasmine.SpyObj<MatchService>;
   });
 
@@ -42,50 +39,49 @@ describe('MatchGuard', () => {
     expect(guard).toBeTruthy();
   });
 
-  it('should navigate to root and return false if matchId is not defined', (done) => {
+  it('should navigate to root and return false if matchId is not defined', async () => {
     const route = {
-      paramMap: {get: jasmine.createSpy().and.returnValue(null)},
+      paramMap: { get: jasmine.createSpy().and.returnValue(null) },
     } as any;
     const state = {} as RouterStateSnapshot;
-    const result = guard.canActivate(route, state) as Observable<boolean>;
+    const result = await TestBed.runInInjectionContext(
+      () => guard(route, state) as Promise<boolean>
+    );
 
     expect(routerService.navigate).toHaveBeenCalledWith(['/']);
 
-    result.subscribe((value) => {
-      expect(value).toBe(false);
-      done();
-    });
+    expect(result).toBe(false);
   });
 
-  it('should navigate to root and return false if match does not exist', (done) => {
+  it('should navigate to root and return false if match does not exist', async () => {
     const route = {
-      paramMap: {get: jasmine.createSpy().and.returnValue('123')},
+      paramMap: { get: jasmine.createSpy().and.returnValue('123') },
     } as any;
 
     service.doesMatchExist.and.returnValue(Promise.resolve(false));
 
     const state = {} as RouterStateSnapshot;
-    const result = guard.canActivate(route, state) as Observable<boolean>;
+    const result = await TestBed.runInInjectionContext(
+      () => guard(route, state) as Promise<boolean>
+    );
 
-
-    result.subscribe((value) => {
-      expect(routerService.navigate).toHaveBeenCalled();
-      expect(value).toBe(false);
-      done();
-    });
+    expect(routerService.navigate).toHaveBeenCalled();
+    expect(result).toBe(false);
   });
 
-  it('should return true if match exists', (done) => {
+  it('should return true if match exists', async () => {
     const route = {
-      paramMap: {get: jasmine.createSpy().and.returnValue('123')},
+      paramMap: { get: jasmine.createSpy().and.returnValue('123') },
     } as any;
     const state = {} as RouterStateSnapshot;
+
     service.doesMatchExist.and.returnValue(Promise.resolve(true));
-    const result = guard.canActivate(route, state) as Observable<boolean>;
+
+    const result = await TestBed.runInInjectionContext(
+      () => guard(route, state) as Promise<boolean>
+    );
+
     expect(routerService.navigate).not.toHaveBeenCalled();
-    result.subscribe((value) => {
-      expect(value).toBe(true);
-      done();
-    });
+    expect(result).toBe(true);
   });
 });

--- a/apps/client/src/app/guards/match/match.guard.ts
+++ b/apps/client/src/app/guards/match/match.guard.ts
@@ -1,46 +1,24 @@
-import { Injectable } from '@angular/core';
-import {
-  ActivatedRouteSnapshot,
-  CanActivate,
-  Router,
-  RouterStateSnapshot,
-  UrlTree,
-} from '@angular/router';
-import { Observable, from } from 'rxjs';
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
 import { MatchService } from 'src/app/services/match/match.service';
 
-@Injectable({
-  providedIn: 'root',
-})
-export class MatchGuard implements CanActivate {
-  constructor(private router: Router, private service: MatchService) {}
+export const MatchGuard: CanActivateFn = async (route): Promise<boolean> => {
+  const router = inject(Router);
+  const service = inject(MatchService);
 
-  canActivate(
-    route: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot
-  ):
-    | Observable<boolean | UrlTree>
-    | Promise<boolean | UrlTree>
-    | boolean
-    | UrlTree {
-    return from(
-      new Promise<boolean>(async (resolve) => {
-        const matchId = route.paramMap.get('id');
+  const matchId = route.paramMap.get('id');
 
-        if (!matchId) {
-          await this.router.navigate(['/']);
-          return resolve(false);
-        }
-
-        const exists = await this.service.doesMatchExist(matchId);
-
-        if (!exists) {
-          await this.router.navigate(['/']);
-          return resolve(false);
-        }
-
-        return resolve(true);
-      })
-    );
+  if (!matchId) {
+    await router.navigate(['/']);
+    return false;
   }
-}
+
+  const exists = await service.doesMatchExist(matchId);
+
+  if (!exists) {
+    await router.navigate(['/']);
+    return false;
+  }
+
+  return true;
+};

--- a/apps/client/src/app/services/match/match.service.spec.ts
+++ b/apps/client/src/app/services/match/match.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { MatchService } from './match.service';
 import { Socket } from 'ngx-socket-io';
 import { Store } from '@ngrx/store';
-import { EMPTY, from, of, toArray } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import {
   changeCards,
   playerJoined,
@@ -129,7 +129,7 @@ describe('MatchService', () => {
 
   describe('@cardsChanged$', () => {
     it('should dispatch changeCards', (done) => {
-      socket.fromEvent.and.returnValue(of({cards: [1, 2]}));
+      socket.fromEvent.and.returnValue(of({ cards: [1, 2] }));
       store.dispatch.and.callThrough();
       service.cardsChanged$().subscribe(() => {
         expect(store.dispatch).toHaveBeenCalledWith(

--- a/apps/client/src/app/services/match/match.service.spec.ts
+++ b/apps/client/src/app/services/match/match.service.spec.ts
@@ -63,6 +63,19 @@ describe('MatchService', () => {
     });
   });
 
+  describe('@playerLeft$', () => {
+    it('should dispatch playerLeft', (done) => {
+      socket.fromEvent.and.returnValue(of({ playerId: '1' }));
+      store.dispatch.and.callThrough();
+      service.playerLeft$().subscribe(() => {
+        expect(store.dispatch).toHaveBeenCalledWith(
+          playerLeft({ playerId: '1' })
+        );
+        done();
+      });
+    });
+  });
+
   describe('@createMatch', () => {
     it('should emit createMatch', () => {
       service.createMatch('hi');

--- a/apps/client/src/app/services/match/match.service.spec.ts
+++ b/apps/client/src/app/services/match/match.service.spec.ts
@@ -3,10 +3,22 @@ import { TestBed } from '@angular/core/testing';
 import { MatchService } from './match.service';
 import { Socket } from 'ngx-socket-io';
 import { Store } from '@ngrx/store';
-import { EMPTY } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
+import {
+  playerJoined,
+  resetGame,
+  revealCards,
+  setMatch,
+  toggleIsAdmin,
+} from 'src/app/store/match.actions';
+import * as events from '@planning-poker/events';
+import { Router } from '@angular/router';
 
 describe('MatchService', () => {
   let service: MatchService;
+  let store: jasmine.SpyObj<Store>;
+  let socket: jasmine.SpyObj<Socket>;
+  let router: jasmine.SpyObj<Router>;
 
   beforeEach(() => {
     const socketSpy = jasmine.createSpyObj('Socket', [
@@ -14,21 +26,135 @@ describe('MatchService', () => {
       'fromEvent',
     ]) as jasmine.SpyObj<Socket>;
 
-    socketSpy.fromEvent.and.callFake((event) => {
-      return EMPTY;
-    });
+    socketSpy.fromEvent.and.returnValue(EMPTY);
 
     const storeSpy = jasmine.createSpyObj('Store', ['select', 'dispatch']);
+    storeSpy.dispatch.and.callThrough();
+
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
     TestBed.configureTestingModule({
       providers: [
         { provide: Socket, useValue: socketSpy },
         { provide: Store, useValue: storeSpy },
+        { provide: Router, useValue: routerSpy },
       ],
     });
     service = TestBed.inject(MatchService);
+    store = TestBed.inject(Store) as jasmine.SpyObj<Store>;
+    socket = TestBed.inject(Socket) as jasmine.SpyObj<Socket>;
+    router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('@createMatch', () => {
+    it('should emit createMatch', () => {
+      service.createMatch('hi');
+      expect(socket.emit).toHaveBeenCalledWith(
+        events.CreateMatchCommand,
+        'hi',
+        jasmine.any(Function)
+      );
+    });
+
+    it('should dispatch toggleIsAdmin if match exists', () => {
+      socket.emit.and.callFake((_event, _data, cb) => {
+        cb({ matchId: '1' });
+      });
+
+      service.createMatch('hi');
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        toggleIsAdmin({ isAdmin: true })
+      );
+    });
+
+    it('should navigate to match after creation', () => {
+      socket.emit.and.callFake((_event, _data, cb) => {
+        cb({ matchId: '1' });
+      });
+
+      service.createMatch('hi');
+
+      expect(router.navigate).toHaveBeenCalledWith(['/match', '1']);
+    });
+  });
+
+  describe('@joinMatch', () => {
+    it('should emit joinMatch', () => {
+      service.joinMatch('2', 'hi', '2');
+      expect(socket.emit).toHaveBeenCalledWith(
+        events.JoinMatchCommand,
+        {
+          matchId: '2',
+          name: 'hi',
+          mode: '2',
+        },
+        jasmine.any(Function)
+      );
+    });
+
+    it('should dispatch setMatch if match exists', () => {
+      const match = {
+        cardDeck: [],
+        id: 'match',
+        name: 'hi',
+        players: [],
+        spectators: [],
+      };
+
+      socket.emit.and.callFake((event, data, cb) => {
+        cb(match);
+      });
+
+      service.joinMatch('2', 'hi', '2');
+
+      expect(store.dispatch).toHaveBeenCalledWith(setMatch({ match }));
+    });
+  });
+
+  describe('@selectCard', () => {
+    it('should emit selectCard', () => {
+      service.selectCard(2);
+      expect(socket.emit).toHaveBeenCalledWith(events.ChooseCardCommand, 2);
+    });
+  });
+
+  describe('@doesMatchExist', () => {
+    it('should return true if match exists', () => {
+      socket.emit.and.callFake((_event, _data, cb) => {
+        cb(true);
+      });
+      service.doesMatchExist('2').then((result) => {
+        expect(result).toBeTrue();
+      });
+    });
+
+    it('should return false if match does not exist', () => {
+      socket.emit.and.callFake((_event, _data, cb) => {
+        cb(false);
+      });
+
+      service.doesMatchExist('2').then((result) => {
+        expect(result).toBeFalse();
+      });
+    });
+  });
+
+  describe('@resetGame', () => {
+    it('should dispatch resetGame', () => {
+      service.resetGame();
+      expect(store.dispatch).toHaveBeenCalledWith(resetGame());
+    });
+  });
+
+  describe('@revealCards', () => {
+    it('should emit revealCards', () => {
+      service.revealCards();
+      expect(store.dispatch).toHaveBeenCalledWith(revealCards());
+    });
   });
 });

--- a/apps/client/src/app/services/match/match.service.spec.ts
+++ b/apps/client/src/app/services/match/match.service.spec.ts
@@ -50,6 +50,19 @@ describe('MatchService', () => {
     expect(service).toBeTruthy();
   });
 
+  describe('@playerJoined$', () => {
+    it('should dispatch playerJoined', (done) => {
+      socket.fromEvent.and.returnValue(of({ id: '1', name: 'Player 1' }));
+      store.dispatch.and.callThrough();
+      service.playerJoined$().subscribe(() => {
+        expect(store.dispatch).toHaveBeenCalledWith(
+          playerJoined({ id: '1', name: 'Player 1' })
+        );
+        done();
+      });
+    });
+  });
+
   describe('@createMatch', () => {
     it('should emit createMatch', () => {
       service.createMatch('hi');

--- a/apps/client/src/app/services/match/match.service.spec.ts
+++ b/apps/client/src/app/services/match/match.service.spec.ts
@@ -6,9 +6,11 @@ import { Store } from '@ngrx/store';
 import { EMPTY, of } from 'rxjs';
 import {
   playerJoined,
+  playerLeft,
   resetGame,
   revealCards,
   setMatch,
+  setPlayerCard,
   toggleIsAdmin,
 } from 'src/app/store/match.actions';
 import * as events from '@planning-poker/events';
@@ -70,6 +72,19 @@ describe('MatchService', () => {
       service.playerLeft$().subscribe(() => {
         expect(store.dispatch).toHaveBeenCalledWith(
           playerLeft({ playerId: '1' })
+        );
+        done();
+      });
+    });
+  });
+
+  describe('@playerSelectedCard$', () => {
+    it('should dispatch playerSelectedCard', (done) => {
+      socket.fromEvent.and.returnValue(of({ playerId: '1', card: 2 }));
+      store.dispatch.and.callThrough();
+      service.playerSelectedCard$().subscribe(() => {
+        expect(store.dispatch).toHaveBeenCalledWith(
+          setPlayerCard({ playerId: '1', card: 2 })
         );
         done();
       });

--- a/apps/client/src/app/services/match/match.service.spec.ts
+++ b/apps/client/src/app/services/match/match.service.spec.ts
@@ -3,8 +3,9 @@ import { TestBed } from '@angular/core/testing';
 import { MatchService } from './match.service';
 import { Socket } from 'ngx-socket-io';
 import { Store } from '@ngrx/store';
-import { EMPTY, of } from 'rxjs';
+import { EMPTY, from, of, toArray } from 'rxjs';
 import {
+  changeCards,
   playerJoined,
   playerLeft,
   resetGame,
@@ -85,6 +86,54 @@ describe('MatchService', () => {
       service.playerSelectedCard$().subscribe(() => {
         expect(store.dispatch).toHaveBeenCalledWith(
           setPlayerCard({ playerId: '1', card: 2 })
+        );
+        done();
+      });
+    });
+  });
+
+  describe('@matchRestarted$', () => {
+    it('should dispatch resetGame', (done) => {
+      socket.fromEvent.and.returnValue(of({}));
+      store.dispatch.and.callThrough();
+      service.matchRestarted$().subscribe(() => {
+        expect(store.dispatch).toHaveBeenCalledWith(resetGame());
+        done();
+      });
+    });
+  });
+
+  describe('@cardsRevealed$', () => {
+    it('should dispatch revealCards', (done) => {
+      socket.fromEvent.and.returnValue(of({}));
+      store.dispatch.and.callThrough();
+      service.cardsRevealed$().subscribe(() => {
+        expect(store.dispatch).toHaveBeenCalledWith(revealCards());
+        done();
+      });
+    });
+  });
+
+  describe('@adminAssigned$', () => {
+    it('should dispatch toggleIsAdmin', (done) => {
+      socket.fromEvent.and.returnValue(of({ playerId: '' }));
+      store.dispatch.and.callThrough();
+      service.adminAssigned$().subscribe(() => {
+        expect(store.dispatch).toHaveBeenCalledWith(
+          toggleIsAdmin({ isAdmin: true })
+        );
+        done();
+      });
+    });
+  });
+
+  describe('@cardsChanged$', () => {
+    it('should dispatch changeCards', (done) => {
+      socket.fromEvent.and.returnValue(of({cards: [1, 2]}));
+      store.dispatch.and.callThrough();
+      service.cardsChanged$().subscribe(() => {
+        expect(store.dispatch).toHaveBeenCalledWith(
+          changeCards({ cards: [1, 2] })
         );
         done();
       });

--- a/apps/client/src/app/services/match/match.service.spec.ts
+++ b/apps/client/src/app/services/match/match.service.spec.ts
@@ -127,6 +127,18 @@ describe('MatchService', () => {
 
       expect(store.dispatch).toHaveBeenCalledWith(setMatch({ match }));
     });
+
+    it('should alert if match does not exist', () => {
+      socket.emit.and.callFake((_event, _data, cb) => {
+        cb(null, { message: 'error' });
+      });
+
+      spyOn(window, 'alert');
+
+      service.joinMatch('2', 'hi', '2');
+
+      expect(window.alert).toHaveBeenCalledWith('error');
+    });
   });
 
   describe('@selectCard', () => {

--- a/apps/client/src/app/services/match/match.service.ts
+++ b/apps/client/src/app/services/match/match.service.ts
@@ -34,18 +34,9 @@ export class MatchService {
   registerEvents() {
     this.playerJoined$().subscribe();
 
-    this.playerLeft$.subscribe(({ playerId }) => {
-      this.store.dispatch(playerLeft({ playerId }));
-    });
+    this.playerLeft$().subscribe();
 
-    this.playerSelectedCard$.subscribe(({ playerId, card }) => {
-      this.store.dispatch(
-        setPlayerCard({
-          playerId,
-          card,
-        })
-      );
-    });
+    this.playerSelectedCard$().subscribe();
 
     this.adminAssigned$.subscribe(() => {
       this.store.dispatch(toggleIsAdmin({ isAdmin: true }));
@@ -82,10 +73,19 @@ export class MatchService {
     );
   }
 
-  get playerSelectedCard$() {
-    return this.io.fromEvent<{ playerId: string; card: number }>(
-      events.PlayerSelectedCard
-    );
+  playerSelectedCard$() {
+    return this.io
+      .fromEvent<{ playerId: string; card: number }>(events.PlayerSelectedCard)
+      .pipe(
+        tap(({ playerId, card }) => {
+          this.store.dispatch(
+            setPlayerCard({
+              playerId,
+              card,
+            })
+          );
+        })
+      );
   }
 
   get matchRestarted$() {

--- a/apps/client/src/app/services/match/match.service.ts
+++ b/apps/client/src/app/services/match/match.service.ts
@@ -74,8 +74,12 @@ export class MatchService {
       );
   }
 
-  get playerLeft$() {
-    return this.io.fromEvent<{ playerId: string }>(events.PlayerLeft);
+  playerLeft$() {
+    return this.io.fromEvent<{ playerId: string }>(events.PlayerLeft).pipe(
+      tap(({ playerId }) => {
+        this.store.dispatch(playerLeft({ playerId }));
+      })
+    );
   }
 
   get playerSelectedCard$() {

--- a/apps/client/src/app/services/match/match.service.ts
+++ b/apps/client/src/app/services/match/match.service.ts
@@ -14,7 +14,7 @@ import {
   resetGame,
   revealCards,
 } from 'src/app/store/match.actions';
-import { EMPTY, from, mergeMap, switchMap, tap } from 'rxjs';
+import { from, tap } from 'rxjs';
 import { State } from 'src/app/store';
 
 @Injectable({

--- a/apps/client/src/app/services/match/match.service.ts
+++ b/apps/client/src/app/services/match/match.service.ts
@@ -14,7 +14,7 @@ import {
   resetGame,
   revealCards,
 } from 'src/app/store/match.actions';
-import { EMPTY, from, switchMap } from 'rxjs';
+import { EMPTY, from, mergeMap, switchMap, tap } from 'rxjs';
 import { State } from 'src/app/store';
 
 @Injectable({
@@ -68,9 +68,8 @@ export class MatchService {
     return this.io
       .fromEvent<{ name: string; id: string }>(events.PlayerJoined)
       .pipe(
-        switchMap(({ id, name }) => {
+        tap(({ id, name }) => {
           this.store.dispatch(playerJoined({ name, id }));
-          return EMPTY;
         })
       );
   }

--- a/apps/client/src/app/services/match/match.service.ts
+++ b/apps/client/src/app/services/match/match.service.ts
@@ -38,21 +38,13 @@ export class MatchService {
 
     this.playerSelectedCard$().subscribe();
 
-    this.adminAssigned$.subscribe(() => {
-      this.store.dispatch(toggleIsAdmin({ isAdmin: true }));
-    });
+    this.adminAssigned$().subscribe();
 
-    this.cardsChanged$.subscribe(({ cards }) => {
-      this.store.dispatch(changeCards({ cards }));
-    });
+    this.cardsChanged$().subscribe();
 
-    this.cardsRevealed$.subscribe(() => {
-      this.store.dispatch(revealCards());
-    });
+    this.cardsRevealed$().subscribe();
 
-    this.matchRestarted$.subscribe(() => {
-      this.store.dispatch(resetGame());
-    });
+    this.matchRestarted$().subscribe();
   }
 
   playerJoined$() {
@@ -88,20 +80,38 @@ export class MatchService {
       );
   }
 
-  get matchRestarted$() {
-    return this.io.fromEvent(events.MatchRestarted);
+  matchRestarted$() {
+    return this.io.fromEvent(events.MatchRestarted).pipe(
+      tap(() => {
+        this.store.dispatch(resetGame());
+      })
+    );
   }
 
-  get cardsRevealed$() {
-    return this.io.fromEvent(events.CardsRevealed);
+  cardsRevealed$() {
+    return this.io.fromEvent(events.CardsRevealed).pipe(
+      tap(() => {
+        this.store.dispatch(revealCards());
+      })
+    );
   }
 
-  get adminAssigned$() {
-    return this.io.fromEvent<{ playerId: string }>(events.AdminAssigned);
+  adminAssigned$() {
+    return this.io.fromEvent<{ playerId: string }>(events.AdminAssigned).pipe(
+      tap(() => {
+        this.store.dispatch(toggleIsAdmin({ isAdmin: true }));
+      })
+    );
   }
 
-  get cardsChanged$() {
-    return this.io.fromEvent<{ cards: number[] }>(events.CardsChanged);
+  cardsChanged$() {
+    return this.io.fromEvent<{ cards: number[] }>(events.CardsChanged).pipe(
+      tap((props) => {
+        console.log('cards changed', props);
+
+        this.store.dispatch(changeCards({ cards: props.cards }));
+      })
+    );
   }
 
   cardDeck$() {

--- a/apps/server/src/db/repository.ts
+++ b/apps/server/src/db/repository.ts
@@ -1,7 +1,6 @@
 import { Match } from "@planning-poker/models";
 import redis from "./redis";
 import log from "../lib/logger";
-import { remove } from "winston";
 
 export async function createMatch(
   matchId: string,
@@ -43,13 +42,14 @@ export async function getMatch(matchId: string): Promise<Match> {
       card: Number(player.card),
     });
   }
-  const spectators: { name: string }[] = [];
+  const spectators: Match["spectators"] = [];
 
   for await (const spectatorId of redis.scanIterator({
     MATCH: `match:${matchId}:spectator:*`,
   })) {
     const spectator = await redis.hGetAll(spectatorId);
     spectators.push({
+      id: spectatorId,
       name: spectator.name,
     });
   }


### PR DESCRIPTION
This pull request includes refactoring of the match service and the addition of new methods such as playerJoined$(), playerLeft$(), playerSelectedCard$(), adminAssigned$(), cardsChanged$(), cardsRevealed$(), and matchRestarted$(). It also includes the removal of unused imports and updates to the spectators array.