### PR TITLE
Make the card deck responsive

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -44,6 +44,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "karma-mocha-reporter": "^2.2.5",
+    "prettier": "^3.1.1",
     "typescript": "~5.2.2"
   }
 }

--- a/apps/client/src/app/components/dialog/dialog.component.css
+++ b/apps/client/src/app/components/dialog/dialog.component.css
@@ -9,7 +9,5 @@
   width: 90%;
   margin: 0 auto;
   max-width: 25rem;
-  min-width: 356px;
-
   box-shadow: 0px 0px 7px var(--accent-color);
 }

--- a/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.html
+++ b/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.html
@@ -1,0 +1,1 @@
+<p>card-deck-modal works!</p>

--- a/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.html
+++ b/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.html
@@ -1,4 +1,7 @@
 <app-dialog>
+  <p style="text-align: center">
+    <strong>Elige una carta 👇</strong>
+  </p>
   <div class="deck-container">
     @for (card of cards; track $index) {
       <app-card

--- a/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.html
+++ b/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.html
@@ -1,1 +1,14 @@
-<p>card-deck-modal works!</p>
+<app-dialog>
+  <div class="deck-container">
+    @for (card of cards; track $index) {
+      <app-card
+        [selected]="selectedCard === card"
+        [value]="cardValue(card)"
+        (select)="selectCard(card)"
+        [ngClass]="{ selected: selectedCard === card }"
+      >
+        {{ card }}
+      </app-card>
+    }
+  </div>
+</app-dialog>

--- a/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.scss
+++ b/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.scss
@@ -10,6 +10,13 @@
   z-index: 1000;
 }
 
+p {
+  font-size: 1.25rem;
+  font-weight: 700;
+  text-align: center;
+  color: white;
+}
+
 .deck-container {
   display: flex;
   justify-content: center;

--- a/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.scss
+++ b/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.scss
@@ -1,0 +1,21 @@
+:host {
+  display: block;
+  max-width: 50%;
+  min-width: 90%;
+  margin: 0 auto;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1000;
+}
+
+.deck-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 2rem 4rem;
+  gap: 1rem;
+  width: 100%;
+}

--- a/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.scss
+++ b/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.scss
@@ -18,4 +18,22 @@
   padding: 2rem 4rem;
   gap: 1rem;
   width: 100%;
+
+  & > * {
+    transition: all 0.2s ease-in-out;
+  }
+
+  & > *:hover {
+    transform: translateY(-10px);
+  }
+
+  & > .selected {
+    transform: translateY(-10px);
+  }
+
+  // If the card is selected, and the user hovers over another card,
+  // the hovered card should not move.
+  &:has(.selected) *:not(.selected):hover {
+    transform: none;
+  }
 }

--- a/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.spec.ts
+++ b/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CardDeckModalComponent } from './card-deck-modal.component';
+
+describe('CardDeckModalComponent', () => {
+  let component: CardDeckModalComponent;
+  let fixture: ComponentFixture<CardDeckModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CardDeckModalComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(CardDeckModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.ts
+++ b/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.ts
@@ -1,11 +1,30 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { MatchService } from 'src/app/services/match/match.service';
+import { toArray } from 'rxjs';
 
 @Component({
   selector: 'match-card-deck-modal',
   templateUrl: './card-deck-modal.component.html',
-  styleUrl: './card-deck-modal.component.scss'
+  styleUrl: './card-deck-modal.component.scss',
 })
 export class CardDeckModalComponent {
+  constructor(private service: MatchService) {}
 
+  @Input() choosenCard: number = -1;
+  @Output() choosenCardChange = new EventEmitter<number>();
+
+  cards: number[] = [];
+
+  ngOnInit() {
+    this.service
+      .cardDeck$()
+      .pipe(toArray())
+      .subscribe((cards) => {
+        this.cards = cards;
+      });
+  }
+
+  chooseCard(card: number) {
+    this.choosenCardChange.emit(card);
+  }
 }

--- a/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.ts
+++ b/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.ts
@@ -10,8 +10,8 @@ import { toArray } from 'rxjs';
 export class CardDeckModalComponent {
   constructor(private service: MatchService) {}
 
-  @Input() choosenCard: number = -1;
-  @Output() choosenCardChange = new EventEmitter<number>();
+  @Input() selectedCard: number = -1;
+  @Output() cardSelect = new EventEmitter<number>();
 
   cards: number[] = [];
 
@@ -24,7 +24,11 @@ export class CardDeckModalComponent {
       });
   }
 
-  chooseCard(card: number) {
-    this.choosenCardChange.emit(card);
+  selectCard(card: number) {
+    this.cardSelect.emit(card);
+  }
+
+  cardValue(card: number) {
+    return card.toString();
   }
 }

--- a/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.ts
+++ b/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'match-card-deck-modal',
+  templateUrl: './card-deck-modal.component.html',
+  styleUrl: './card-deck-modal.component.scss'
+})
+export class CardDeckModalComponent {
+
+}

--- a/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.ts
+++ b/apps/client/src/app/pages/match/components/card-deck-modal/card-deck-modal.component.ts
@@ -25,7 +25,10 @@ export class CardDeckModalComponent {
   }
 
   selectCard(card: number) {
-    this.cardSelect.emit(card);
+    this.selectedCard = card;
+    setTimeout(() => {
+      this.cardSelect.emit(card);
+    }, 1000);
   }
 
   cardValue(card: number) {

--- a/apps/client/src/app/pages/match/components/card-deck/card-deck.component.scss
+++ b/apps/client/src/app/pages/match/components/card-deck/card-deck.component.scss
@@ -14,6 +14,14 @@
   }
 }
 
+p {
+  display: none;
+
+  @include lg {
+    display: block;
+  }
+}
+
 .card-deck-container {
   display: none;
 

--- a/apps/client/src/app/pages/match/components/card-deck/card-deck.component.ts
+++ b/apps/client/src/app/pages/match/components/card-deck/card-deck.component.ts
@@ -1,5 +1,4 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { MatchService } from 'src/app/services/match/match.service';
 import { reduce } from 'rxjs';
 
@@ -11,7 +10,9 @@ import { reduce } from 'rxjs';
 export class CardDeckComponent {
   constructor(private service: MatchService) {}
 
-  selectedCard = -1;
+  @Output() cardSelect = new EventEmitter<number>();
+
+  @Input() selectedCard = -1;
 
   get cardDeck$() {
     return this.service.cardDeck$().pipe(
@@ -23,8 +24,7 @@ export class CardDeckComponent {
 
   onSelectedCard(card: number) {
     if (this.selectedCard === -1) {
-      this.selectedCard = card;
-      this.service.selectCard(card);
+      this.cardSelect.emit(card);
     }
   }
 }

--- a/apps/client/src/app/pages/match/components/invite-dialog/invite-dialog.component.scss
+++ b/apps/client/src/app/pages/match/components/invite-dialog/invite-dialog.component.scss
@@ -1,5 +1,9 @@
 @import "../../../../styles/form-elements";
 
+app-dialog {
+  min-width: 356px;
+}
+
 .invite-dialog {
   &__header {
     width: 100%;

--- a/apps/client/src/app/pages/match/components/join-dialog/join-dialog.component.scss
+++ b/apps/client/src/app/pages/match/components/join-dialog/join-dialog.component.scss
@@ -1,3 +1,7 @@
+app-dialog {
+  min-width: 356px;
+}
+
 form {
   display: flex;
   flex-direction: column;

--- a/apps/client/src/app/pages/match/match.component.html
+++ b/apps/client/src/app/pages/match/match.component.html
@@ -1,13 +1,20 @@
 @if (!isUserChosed) {
-<div class="backdrop"></div>
-<match-join-dialog (onSubmit)="handleUserChoose($event)" class="dialog-wrapper"></match-join-dialog>
-} @if (isInviteModalOpen) {
-<div class="backdrop"></div>
-<match-invite-dialog (close)="handleInviteModalClose()" class="dialog-wrapper"></match-invite-dialog>
+  <div class="backdrop"></div>
+  <match-join-dialog
+    (onSubmit)="handleUserChoose($event)"
+    class="dialog-wrapper"
+  ></match-join-dialog>
 }
-@if (selectedCard === -1) {
-<div class="backdrop"></div>
-<match-card-deck-modal></match-card-deck-modal>
+@if (isInviteModalOpen) {
+  <div class="backdrop"></div>
+  <match-invite-dialog
+    (close)="handleInviteModalClose()"
+    class="dialog-wrapper"
+  ></match-invite-dialog>
+}
+@if (isCardDeckModalOpen) {
+  <div class="backdrop"></div>
+  <match-card-deck-modal></match-card-deck-modal>
 }
 <div class="page-container">
   <nav>
@@ -22,10 +29,19 @@
     </ng-template>
     <div class="right">
       <div class="spectators">
-        <app-avatar *ngFor="let spectator of spectators$" [showLabel]="false" size="small"
-          [name]="spectator.name"></app-avatar>
-        <app-avatar *ngIf="spectatorsCount > 3" [showLabel]="false" size="small" [customPrefix]="spectatorCountLabel"
-          [backgroundColor]="'white'"></app-avatar>
+        <app-avatar
+          *ngFor="let spectator of spectators$"
+          [showLabel]="false"
+          size="small"
+          [name]="spectator.name"
+        ></app-avatar>
+        <app-avatar
+          *ngIf="spectatorsCount > 3"
+          [showLabel]="false"
+          size="small"
+          [customPrefix]="spectatorCountLabel"
+          [backgroundColor]="'white'"
+        ></app-avatar>
       </div>
       <div class="menu">
         <app-button (click)="handleInviteModalOpen()" variant="outlined">
@@ -36,6 +52,9 @@
   </nav>
   <main>
     <match-desk></match-desk>
-    <match-card-deck [selectedCard]="selectedCard" (cardSelect)="onSelectedCard($event)"></match-card-deck>
+    <match-card-deck
+      [selectedCard]="selectedCard"
+      (cardSelect)="onSelectedCard($event)"
+    ></match-card-deck>
   </main>
 </div>

--- a/apps/client/src/app/pages/match/match.component.html
+++ b/apps/client/src/app/pages/match/match.component.html
@@ -5,6 +5,10 @@
 <div class="backdrop"></div>
 <match-invite-dialog (close)="handleInviteModalClose()" class="dialog-wrapper"></match-invite-dialog>
 }
+@if (selectedCard === -1) {
+<div class="backdrop"></div>
+<match-card-deck-modal></match-card-deck-modal>
+}
 <div class="page-container">
   <nav>
     <div class="logo">

--- a/apps/client/src/app/pages/match/match.component.html
+++ b/apps/client/src/app/pages/match/match.component.html
@@ -1,15 +1,9 @@
 @if (!isUserChosed) {
 <div class="backdrop"></div>
-<match-join-dialog
-  (onSubmit)="handleUserChoose($event)"
-  class="dialog-wrapper"
-></match-join-dialog>
+<match-join-dialog (onSubmit)="handleUserChoose($event)" class="dialog-wrapper"></match-join-dialog>
 } @if (isInviteModalOpen) {
 <div class="backdrop"></div>
-<match-invite-dialog
-  (close)="handleInviteModalClose()"
-  class="dialog-wrapper"
-></match-invite-dialog>
+<match-invite-dialog (close)="handleInviteModalClose()" class="dialog-wrapper"></match-invite-dialog>
 }
 <div class="page-container">
   <nav>
@@ -24,19 +18,10 @@
     </ng-template>
     <div class="right">
       <div class="spectators">
-        <app-avatar
-          *ngFor="let spectator of spectators$"
-          [showLabel]="false"
-          size="small"
-          [name]="spectator.name"
-        ></app-avatar>
-        <app-avatar
-          *ngIf="spectatorsCount > 3"
-          [showLabel]="false"
-          size="small"
-          [customPrefix]="spectatorCountLabel"
-          [backgroundColor]="'white'"
-        ></app-avatar>
+        <app-avatar *ngFor="let spectator of spectators$" [showLabel]="false" size="small"
+          [name]="spectator.name"></app-avatar>
+        <app-avatar *ngIf="spectatorsCount > 3" [showLabel]="false" size="small" [customPrefix]="spectatorCountLabel"
+          [backgroundColor]="'white'"></app-avatar>
       </div>
       <div class="menu">
         <app-button (click)="handleInviteModalOpen()" variant="outlined">
@@ -47,6 +32,6 @@
   </nav>
   <main>
     <match-desk></match-desk>
-    <match-card-deck></match-card-deck>
+    <match-card-deck [selectedCard]="selectedCard" (cardSelect)="onSelectedCard($event)"></match-card-deck>
   </main>
 </div>

--- a/apps/client/src/app/pages/match/match.component.html
+++ b/apps/client/src/app/pages/match/match.component.html
@@ -14,7 +14,10 @@
 }
 @if (isCardDeckModalOpen) {
   <div class="backdrop"></div>
-  <match-card-deck-modal></match-card-deck-modal>
+  <match-card-deck-modal
+    [selectedCard]="selectedCard"
+    (cardSelect)="onSelectedCard($event)"
+  ></match-card-deck-modal>
 }
 <div class="page-container">
   <nav>

--- a/apps/client/src/app/pages/match/match.component.ts
+++ b/apps/client/src/app/pages/match/match.component.ts
@@ -80,4 +80,8 @@ export class MatchComponent implements OnInit {
       this.matchService.selectCard(card);
     }
   }
+
+  get isCardDeckModalOpen() {
+    return this.selectedCard !== -1 && this.isUserChosed;
+  }
 }

--- a/apps/client/src/app/pages/match/match.component.ts
+++ b/apps/client/src/app/pages/match/match.component.ts
@@ -15,14 +15,14 @@ export class MatchComponent implements OnInit {
     private route: ActivatedRoute,
     private store: Store<{
       match: State;
-    }>
+    }>,
   ) {
     this.getSpectators$().subscribe((spectators) => {
       this.spectators$ = spectators;
     });
   }
 
-  isUserChosed: boolean = true;
+  isUserChosed: boolean = false;
   match$ = this.store.select('match');
   isInviteModalOpen = false;
   spectators$: State['match']['spectators'] = [];
@@ -37,7 +37,7 @@ export class MatchComponent implements OnInit {
   get spectatorsCount$() {
     return this.matchService.getSpectators().pipe(
       switchMap((spectators) => from(spectators)),
-      scan((acc) => acc + 1, 0)
+      scan((acc) => acc + 1, 0),
     );
   }
 
@@ -62,7 +62,7 @@ export class MatchComponent implements OnInit {
     this.matchService.joinMatch(
       this.route.snapshot.paramMap.get('id')!,
       data.name,
-      data.mode
+      data.mode,
     );
   }
 
@@ -81,7 +81,11 @@ export class MatchComponent implements OnInit {
     }
   }
 
+  get isUserPlayer() {
+    return true;
+  }
+
   get isCardDeckModalOpen() {
-    return this.selectedCard === -1 && this.isUserChosed;
+    return this.selectedCard === -1 && this.isUserChosed && this.isUserPlayer;
   }
 }

--- a/apps/client/src/app/pages/match/match.component.ts
+++ b/apps/client/src/app/pages/match/match.component.ts
@@ -82,6 +82,6 @@ export class MatchComponent implements OnInit {
   }
 
   get isCardDeckModalOpen() {
-    return this.selectedCard !== -1 && this.isUserChosed;
+    return this.selectedCard === -1 && this.isUserChosed;
   }
 }

--- a/apps/client/src/app/pages/match/match.component.ts
+++ b/apps/client/src/app/pages/match/match.component.ts
@@ -22,10 +22,11 @@ export class MatchComponent implements OnInit {
     });
   }
 
-  isUserChosed: boolean = false;
+  isUserChosed: boolean = true;
   match$ = this.store.select('match');
   isInviteModalOpen = false;
   spectators$: State['match']['spectators'] = [];
+  selectedCard = -1;
 
   getSpectators$() {
     return this.matchService
@@ -71,5 +72,12 @@ export class MatchComponent implements OnInit {
 
   handleInviteModalClose() {
     this.isInviteModalOpen = false;
+  }
+
+  onSelectedCard(card: number) {
+    if (this.selectedCard === -1) {
+      this.selectedCard = card;
+      this.matchService.selectCard(card);
+    }
   }
 }

--- a/apps/client/src/app/pages/match/match.module.ts
+++ b/apps/client/src/app/pages/match/match.module.ts
@@ -13,6 +13,7 @@ import { InviteDialogComponent } from './components/invite-dialog/invite-dialog.
 import { MatIconModule } from '@angular/material/icon';
 import { CardDeckComponent } from './components/card-deck/card-deck.component';
 import { ButtonComponent } from 'src/app/components/button/button.component';
+import { CardDeckModalComponent } from './components/card-deck-modal/card-deck-modal.component';
 
 @NgModule({
   declarations: [
@@ -21,6 +22,7 @@ import { ButtonComponent } from 'src/app/components/button/button.component';
     DeskComponent,
     InviteDialogComponent,
     CardDeckComponent,
+    CardDeckModalComponent
   ],
   imports: [
     CommonModule,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       karma-mocha-reporter:
         specifier: ^2.2.5
         version: 2.2.5(karma@6.4.2)
+      prettier:
+        specifier: ^3.1.1
+        version: 3.1.1
       typescript:
         specifier: ~5.2.2
         version: 5.2.2
@@ -7027,6 +7030,12 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
+
+  /prettier@3.1.1:
+    resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
+    engines: {node: '>=14'}
+    hasBin: true
     dev: true
 
   /pretty-bytes@5.6.0:


### PR DESCRIPTION
This pull request includes the following changes:

- Lift up card-deck state to match

- Create the match-card-deck-modal component

- Add prettier package to package.json and pnpm-lock.yaml

- Refactor match component HTML and TypeScript

- Fix condition in isCardDeckModalOpen

- Add properties and methods to card deck modal

- Remove min-width property from dialog component CSS

- Refactor card-deck-modal component

- Add animations to the cards

- Update match.component.html to pass selectedCard and handle cardSelect event

- Add delay to selectCard

- Hide the card deck label when mobile

- Add title to the modal

- Fix dialog width bug

- Update isUserChosed to false