### PR TITLE
Refactor match service to use SocketIoClientService

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -29,7 +29,6 @@
     "http-server": "^14.1.1",
     "immer": "^10.0.3",
     "modern-normalize": "^2.0.0",
-    "ngx-socket-io": "^4.6.1",
     "rxjs": "~7.8.0",
     "socket.io-client": "^4.7.3",
     "tslib": "^2.3.0",

--- a/apps/client/src/app/app.module.ts
+++ b/apps/client/src/app/app.module.ts
@@ -6,8 +6,6 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { CreateMatchFormComponent } from './pages/create/create-match-form.component';
 import { ReactiveFormsModule } from '@angular/forms';
-import { SocketIoModule } from 'ngx-socket-io';
-import { environment } from 'src/environments/environment';
 import { StoreModule } from '@ngrx/store';
 import { matchReducer } from './store';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
@@ -22,7 +20,6 @@ import { EffectsModule } from '@ngrx/effects';
     AppRoutingModule,
     HttpClientModule,
     ReactiveFormsModule,
-    SocketIoModule.forRoot({ url: environment.baseUrl }),
     StoreModule.forRoot({ match: matchReducer }),
     StoreDevtoolsModule.instrument({ maxAge: 25, logOnly: !isDevMode() }),
     BrowserAnimationsModule,
@@ -32,4 +29,4 @@ import { EffectsModule } from '@ngrx/effects';
   providers: [],
   bootstrap: [AppComponent],
 })
-export class AppModule {}
+export class AppModule { }

--- a/apps/client/src/app/guards/match/match.guard.spec.ts
+++ b/apps/client/src/app/guards/match/match.guard.spec.ts
@@ -1,9 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 
-import { Socket } from 'ngx-socket-io';
 import { Router, RouterStateSnapshot } from '@angular/router';
 import { MatchService } from 'src/app/services/match/match.service';
 import { MatchGuard } from './match.guard';
+import { SocketIoClientService } from 'src/app/services/socket.io-client/socket.io-client.service';
+import { EMPTY } from 'rxjs';
 
 describe('MatchGuard', () => {
   let guard: typeof MatchGuard;
@@ -11,9 +12,12 @@ describe('MatchGuard', () => {
   let service: jasmine.SpyObj<MatchService>;
 
   beforeEach(() => {
-    const socketSpy = jasmine.createSpyObj('Socket', [
+    const socketSpy = jasmine.createSpyObj('SocketIoClientService', [
       'emit',
-    ]) as jasmine.SpyObj<Socket>;
+      'fromEvent',
+    ]) as jasmine.SpyObj<SocketIoClientService>;
+
+    socketSpy.fromEvent.and.returnValue(EMPTY);
 
     const routerSpy = jasmine.createSpyObj('Router', [
       'navigate',
@@ -25,7 +29,7 @@ describe('MatchGuard', () => {
 
     TestBed.configureTestingModule({
       providers: [
-        { provide: Socket, useValue: socketSpy },
+        { provide: SocketIoClientService, useValue: socketSpy },
         { provide: Router, useValue: routerSpy },
         { provide: MatchService, useValue: serviceSpy },
       ],

--- a/apps/client/src/app/pages/match/components/join-dialog/join-dialog.component.ts
+++ b/apps/client/src/app/pages/match/components/join-dialog/join-dialog.component.ts
@@ -10,9 +10,9 @@ import {
   styleUrls: ['./join-dialog.component.scss'],
 })
 export class JoinDialogComponent {
-  constructor(private fb: FormBuilder) {}
+  constructor(private fb: FormBuilder) { }
 
-  @Output() onSubmit = new EventEmitter<{ name: string; mode: string }>();
+  @Output() onSubmit = new EventEmitter<{ name: string; mode: "player" | "spectator" }>();
 
   form = this.fb.group({
     name: this.fb.control('', {
@@ -27,7 +27,7 @@ export class JoinDialogComponent {
       ],
     }),
     mode: this.fb.control<string>('', {
-      validators: [Validators.required],
+      validators: [Validators.required, Validators.pattern(/^(player|spectator)$/)],
     }),
   });
 
@@ -37,7 +37,7 @@ export class JoinDialogComponent {
 
   handleSubmit() {
     if (this.form.valid) {
-      this.onSubmit.emit(this.form.value as { name: string; mode: string });
+      this.onSubmit.emit(this.form.value as { name: string; mode: "player" | "spectator" });
     }
 
     this.form.markAllAsTouched();

--- a/apps/client/src/app/pages/match/match.component.ts
+++ b/apps/client/src/app/pages/match/match.component.ts
@@ -33,7 +33,7 @@ export class MatchComponent implements OnInit {
     return this.match?.name;
   }
 
-  handleUserChoose(data: { name: string; mode: string }) {
+  handleUserChoose(data: { name: string; mode: "player" | "spectator" }) {
     this.isUserChosed = true;
     this.matchService.joinMatch(
       this.route.snapshot.paramMap.get('id')!,

--- a/apps/client/src/app/services/match/match.service.spec.ts
+++ b/apps/client/src/app/services/match/match.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
 import { MatchService } from './match.service';
-import { Socket } from 'ngx-socket-io';
 import { Store } from '@ngrx/store';
 import { EMPTY, of } from 'rxjs';
 import {
@@ -18,18 +17,19 @@ import {
 } from 'src/app/store/match.actions';
 import * as events from '@planning-poker/events';
 import { ActivatedRoute, Router } from '@angular/router';
+import { SocketIoClientService } from '../socket.io-client/socket.io-client.service';
 
 describe('MatchService', () => {
   let service: MatchService;
   let store: jasmine.SpyObj<Store>;
-  let socket: jasmine.SpyObj<Socket>;
+  let socket: jasmine.SpyObj<SocketIoClientService>;
   let router: jasmine.SpyObj<Router>;
 
   beforeEach(() => {
-    const socketSpy = jasmine.createSpyObj('Socket', [
+    const socketSpy = jasmine.createSpyObj('SocketIoClientService', [
       'emit',
       'fromEvent',
-    ]) as jasmine.SpyObj<Socket>;
+    ]) as jasmine.SpyObj<SocketIoClientService>;
 
     socketSpy.fromEvent.and.returnValue(EMPTY);
 
@@ -40,7 +40,7 @@ describe('MatchService', () => {
 
     TestBed.configureTestingModule({
       providers: [
-        { provide: Socket, useValue: socketSpy },
+        { provide: SocketIoClientService, useValue: socketSpy },
         { provide: Store, useValue: storeSpy },
         { provide: Router, useValue: routerSpy },
         {
@@ -56,7 +56,7 @@ describe('MatchService', () => {
     });
     service = TestBed.inject(MatchService);
     store = TestBed.inject(Store) as jasmine.SpyObj<Store>;
-    socket = TestBed.inject(Socket) as jasmine.SpyObj<Socket>;
+    socket = TestBed.inject(SocketIoClientService) as jasmine.SpyObj<SocketIoClientService>;
     router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
   });
 
@@ -200,9 +200,7 @@ describe('MatchService', () => {
     });
 
     it('should navigate to match after creation', () => {
-      socket.emit.and.callFake((_event, _data, cb) => {
-        cb('1');
-      });
+      socket.emit.and.callFake((_event, _data, cb) => {})
 
       service.createMatch('hi');
 

--- a/apps/client/src/app/services/match/match.service.ts
+++ b/apps/client/src/app/services/match/match.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { Socket } from 'ngx-socket-io';
 import * as events from '@planning-poker/events';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Match } from '@planning-poker/models';

--- a/apps/client/src/app/services/socket.io-client/socket.io-client.service.spec.ts
+++ b/apps/client/src/app/services/socket.io-client/socket.io-client.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SocketIoClientService } from './socket.io-client.service';
+
+describe('SocketIoClientService', () => {
+  let service: SocketIoClientService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SocketIoClientService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/apps/client/src/app/services/socket.io-client/socket.io-client.service.ts
+++ b/apps/client/src/app/services/socket.io-client/socket.io-client.service.ts
@@ -18,12 +18,12 @@ export class SocketIoClientService {
     });
   }
 
-  fromEvent(event: keyof ClientToServerEvents): Observable<ClientToServerEvents[typeof event]> {
-    return new Observable<ClientToServerEvents[typeof event]>(subscriber => {
-      const listener = (data: ClientToServerEvents[typeof event]) => {
-        subscriber.next(data);
-      };
 
+  fromEvent<T extends keyof ClientToServerEvents>(event: T): Observable<Parameters<ClientToServerEvents[T]>[0]> {
+    return new Observable<Parameters<ClientToServerEvents[T]>[0]>(subscriber => {
+      const listener = (...args: Parameters<ClientToServerEvents[T]>) => {
+        subscriber.next(args[0]);
+      }
       // I use any here because this.socket.on expects some events that are not in ClientToServerEvents
       // The important thing is that from event has autocomplete and type checking
       const newEvent: any = event;
@@ -32,7 +32,7 @@ export class SocketIoClientService {
     });
   }
 
-  emit(event: keyof ServerToClientEvents, ...args: Parameters<ServerToClientEvents[typeof event]>): void {
+  emit<T extends keyof ServerToClientEvents>(event: T, ...args: Parameters<ServerToClientEvents[T]>): void {
     this.socket.emit(event, ...args);
   }
 }

--- a/apps/client/src/app/services/socket.io-client/socket.io-client.service.ts
+++ b/apps/client/src/app/services/socket.io-client/socket.io-client.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SocketIoClientService {
+
+  constructor() { }
+}

--- a/apps/client/src/app/services/socket.io-client/socket.io-client.service.ts
+++ b/apps/client/src/app/services/socket.io-client/socket.io-client.service.ts
@@ -1,9 +1,38 @@
 import { Injectable } from '@angular/core';
+import { ClientToServerEvents, ServerToClientEvents } from '@planning-poker/events';
+import { Observable } from 'rxjs';
+import { Socket, io } from 'socket.io-client';
+import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class SocketIoClientService {
+  public readonly socket: Socket<ClientToServerEvents, ServerToClientEvents>
 
-  constructor() { }
+  constructor() {
+    const sessionId = sessionStorage.getItem('sessionId');
+    this.socket = io(environment.baseUrl, {
+      transports: ['websocket'],
+      auth: { sessionId }
+    });
+  }
+
+  fromEvent(event: keyof ClientToServerEvents): Observable<ClientToServerEvents[typeof event]> {
+    return new Observable<ClientToServerEvents[typeof event]>(subscriber => {
+      const listener = (data: ClientToServerEvents[typeof event]) => {
+        subscriber.next(data);
+      };
+
+      // I use any here because this.socket.on expects some events that are not in ClientToServerEvents
+      // The important thing is that from event has autocomplete and type checking
+      const newEvent: any = event;
+
+      this.socket.on(newEvent, listener);
+    });
+  }
+
+  emit(event: keyof ServerToClientEvents, ...args: Parameters<ServerToClientEvents[typeof event]>): void {
+    this.socket.emit(event, ...args);
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       modern-normalize:
         specifier: ^2.0.0
         version: 2.0.0
-      ngx-socket-io:
-        specifier: ^4.6.1
-        version: 4.6.1(@angular/common@17.0.2)(@angular/core@17.0.2)(rxjs@7.8.1)
       rxjs:
         specifier: ~7.8.0
         version: 7.8.1
@@ -92,7 +89,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: ^17.0.0
-        version: 17.0.0(@angular/compiler-cli@17.0.2)(@types/node@20.9.0)(karma@6.4.2)(typescript@5.2.2)
+        version: 17.0.0(@angular/compiler-cli@17.0.2)(karma@6.4.2)(typescript@5.2.2)
       '@angular/cli':
         specifier: ^17.0.0
         version: 17.0.0
@@ -214,7 +211,7 @@ packages:
       - chokidar
     dev: true
 
-  /@angular-devkit/build-angular@17.0.0(@angular/compiler-cli@17.0.2)(@types/node@20.9.0)(karma@6.4.2)(typescript@5.2.2):
+  /@angular-devkit/build-angular@17.0.0(@angular/compiler-cli@17.0.2)(karma@6.4.2)(typescript@5.2.2):
     resolution: {integrity: sha512-hkV8k4moAnUquac2Dz5XPd5izDDgEF82NeUkSwizcTaqlJqYOdmWASMsXyVBzdrTmDtFKQiphfA96i7eo5MlvA==}
     engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
@@ -311,7 +308,7 @@ packages:
       tslib: 2.6.2
       typescript: 5.2.2
       undici: 5.27.2
-      vite: 4.5.0(@types/node@20.9.0)(less@4.2.0)(sass@1.69.5)(terser@5.24.0)
+      vite: 4.5.0(less@4.2.0)(sass@1.69.5)(terser@5.24.0)
       webpack: 5.89.0(esbuild@0.19.5)
       webpack-dev-middleware: 6.1.1(webpack@5.89.0)
       webpack-dev-server: 4.15.1(webpack@5.89.0)
@@ -660,7 +657,7 @@ packages:
       '@babel/traverse': 7.23.3
       '@babel/types': 7.23.3
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -683,7 +680,7 @@ packages:
       '@babel/traverse': 7.23.3
       '@babel/types': 7.23.3
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -774,7 +771,7 @@ packages:
       '@babel/core': 7.23.2
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -1835,7 +1832,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.3
       '@babel/types': 7.23.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3598,7 +3595,7 @@ packages:
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0
     dependencies:
-      vite: 4.5.0(@types/node@20.9.0)(less@4.2.0)(sass@1.69.5)(terser@5.24.0)
+      vite: 4.5.0(less@4.2.0)(sass@1.69.5)(terser@5.24.0)
     dev: true
 
   /@vitest/coverage-v8@1.1.3(vitest@1.1.3):
@@ -3852,7 +3849,7 @@ packages:
     resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4656,11 +4653,6 @@ packages:
       browserslist: 4.22.1
     dev: true
 
-  /core-js@3.33.2:
-    resolution: {integrity: sha512-XeBzWI6QL3nJQiHmdzbAOiMYqjrb7hwU7A39Qhvd/POSa/t9E1AeZyEZx3fNvp/vtM8zXwhoL0FsiS0hD0pruQ==}
-    requiresBuild: true
-    dev: false
-
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
@@ -4797,6 +4789,17 @@ packages:
     dependencies:
       ms: 2.1.2
 
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -4808,6 +4811,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 5.5.0
+    dev: true
 
   /deep-eql@4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
@@ -5000,7 +5004,7 @@ packages:
     resolution: {integrity: sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==}
     dependencies:
       '@socket.io/component-emitter': 3.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       engine.io-parser: 5.2.1
       ws: 8.11.0
       xmlhttprequest-ssl: 2.0.0
@@ -5024,7 +5028,7 @@ packages:
       base64id: 2.0.0
       cookie: 0.4.2
       cors: 2.8.5
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       engine.io-parser: 5.2.1
       ws: 8.11.0
     transitivePeerDependencies:
@@ -5646,6 +5650,7 @@ packages:
   /has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
+    dev: true
 
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -5764,7 +5769,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5826,7 +5831,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6139,7 +6144,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -6508,7 +6513,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       flatted: 3.2.9
       rfdc: 1.3.0
       streamroller: 3.1.5
@@ -6879,28 +6884,6 @@ packages:
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
-
-  /ngx-socket-io@4.6.1(@angular/common@17.0.2)(@angular/core@17.0.2)(rxjs@7.8.1):
-    resolution: {integrity: sha512-R8Ja/f9Kj+SOLk8WH+uwKrpaoTwiW5/DXmSpBKfzy7SzfoUUxQSCzVGJ4PZ20UfqsT1KKhF3kqqsxWdkPWliLQ==}
-    peerDependencies:
-      '@angular/common': ^17.0.0
-      '@angular/core': ^17.0.0
-      rxjs: ^7.0.0
-    dependencies:
-      '@angular/common': 17.0.2(@angular/core@17.0.2)(rxjs@7.8.1)
-      '@angular/core': 17.0.2(rxjs@7.8.1)(zone.js@0.14.2)
-      core-js: 3.33.2
-      reflect-metadata: 0.1.13
-      rxjs: 7.8.1
-      socket.io: 4.7.2
-      socket.io-client: 4.7.3
-      tslib: 2.6.2
-      zone.js: 0.14.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: false
 
   /nice-napi@1.0.2:
     resolution: {integrity: sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==}
@@ -7695,6 +7678,7 @@ packages:
 
   /reflect-metadata@0.1.13:
     resolution: {integrity: sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==}
+    dev: true
 
   /regenerate-unicode-properties@10.1.1:
     resolution: {integrity: sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==}
@@ -8196,7 +8180,7 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       '@socket.io/component-emitter': 3.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       engine.io-client: 6.5.3
       socket.io-parser: 4.2.4
     transitivePeerDependencies:
@@ -8209,7 +8193,7 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       '@socket.io/component-emitter': 3.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -8220,7 +8204,7 @@ packages:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.5
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       engine.io: 6.5.4
       socket.io-adapter: 2.5.2
       socket.io-parser: 4.2.4
@@ -8242,7 +8226,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -8315,7 +8299,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -8329,7 +8313,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -8394,7 +8378,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -8471,6 +8455,7 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       has-flag: 3.0.0
+    dev: true
 
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -8674,7 +8659,7 @@ packages:
     engines: {node: ^16.14.0 || >=18.0.0}
     dependencies:
       '@tufjs/models': 2.0.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       make-fetch-happen: 13.0.0
     transitivePeerDependencies:
       - supports-color
@@ -8871,7 +8856,7 @@ packages:
       - terser
     dev: true
 
-  /vite@4.5.0(@types/node@20.9.0)(less@4.2.0)(sass@1.69.5)(terser@5.24.0):
+  /vite@4.5.0(less@4.2.0)(sass@1.69.5)(terser@5.24.0):
     resolution: {integrity: sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -8899,7 +8884,6 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.9.0
       esbuild: 0.18.20
       less: 4.2.0
       postcss: 8.4.31


### PR DESCRIPTION
This pull request refactors the match service to use the newly implemented SocketIoClientService instead of the ngx-socket-io library. It also includes fixes for the match tests.